### PR TITLE
Fixes #138; Adds routing table according to spec

### DIFF
--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -64,7 +64,7 @@ export class Configuration {
     const nodeList = JSON.parse(this.fs.readFileSync(file, "utf8").toString());
 
     for (const serviceNode of nodeList.serviceNodes) {
-      this.nodes.push(new Node(new Blockchain("", ""), serviceNode));
+      this.nodes.push(new Node(new Blockchain("", ""), serviceNode, "")); // Empty var added for publicKey
     }
   }
 }

--- a/src/models/dispatch.ts
+++ b/src/models/dispatch.ts
@@ -137,7 +137,7 @@ export class Dispatch {
           if (element.ips) {
             // Create a Node object for each item inside the dataKey object, IP:PORT
             element.ips.forEach((ipPort: string) => {
-              const node = new Node(blockchain, ipPort);
+              const node = new Node(blockchain, ipPort, ""); // Empty var added for publicKey
               nodes.push(node);
             });
           }

--- a/src/models/routing.ts
+++ b/src/models/routing.ts
@@ -32,7 +32,7 @@ export class Routing {
      * Reads an array of random nodes from the routing table
      * @param {number} count - desired number of nodes returned
      */
-    public readRandomNodes(count: number) {
+    public readRandomNodes(count: number): Node[] {
         const nodes = this.nodes;
         // Shuffle array then return the slice
         const shuffled = nodes.sort(() => 0.5 - Math.random());
@@ -42,7 +42,7 @@ export class Routing {
     /**
      * Reads a random node from the routing table based on blockchain netID
      */
-    public readRandomNode() {
+    public readRandomNode(): Node {
         return this.nodes[Math.floor(Math.random() * this.nodes.length)];
     }
 
@@ -50,13 +50,13 @@ export class Routing {
      * Reads a specific node from the routing table based on public key
      * @param {string} publicKey - public key attached to the node
      */
-    public readNode(publicKey: string) {
+    public readNode(publicKey: string): Node {
         for(let i = 0; i < this.nodes.length; i++) {
             if (this.nodes[i].publicKey === publicKey) {
                 return this.nodes[i];
             }
         }
-        return new Error("Node not found in routing table.");
+        throw new Error("Node not found in routing table.");
     }
 
     /**

--- a/src/models/routing.ts
+++ b/src/models/routing.ts
@@ -1,0 +1,95 @@
+import { Node } from "./node";
+import { Configuration } from "../configuration/configuration";
+
+/**
+ *
+ *
+ * @class Routing
+ */
+export class Routing {
+    public readonly nodes: { [netID: string]: Node[] } = {};
+    public readonly configuration: Configuration;
+    /**
+    * Creates an instance of routing.
+    * @param {Array} nodes - Array holding the initial node(s).
+    * @param {Configuration} configuration - Configuration object.
+    * @memberof Routing
+    */
+    constructor(nodes: Node[], configuration: Configuration) {
+        let routingNodes: { [netID: string]: Node[] } = {};
+        nodes.forEach(function (node) {
+            routingNodes[node.blockchain.netID] = routingNodes[node.blockchain.netID] || [];
+            routingNodes[node.blockchain.netID].push(node);
+            if (routingNodes[node.blockchain.netID].length  > configuration.maxNodes) {
+                throw new Error("Routing table cannot contain more than the specified maxNodes per blockchain.");
+            }
+        });
+
+        if (Object.keys(routingNodes).length < 1) {
+            throw new Error("Routing table must be initialized with at least one node.");
+        }
+
+        this.nodes = routingNodes;
+        this.configuration = configuration;
+    }
+
+    /**
+    * Reads an array of random nodes from the routing table based on blockchain netID
+    * @param {string} netID - blockchain netID
+    * @param {number} count - desired number of nodes returned
+    */
+    public readRandomNodes(netID: string, count: number) {
+        let nodes = this.nodes[netID];
+        // Shuffle array then return the slice
+        const shuffled = nodes.sort(() => 0.5 - Math.random());
+        return shuffled.slice(0, count);
+    }
+
+    /**
+    * Reads a random node from the routing table based on blockchain netID
+    * @param {string} netID - blockchain netID
+    */
+    public readRandomNode(netID: string) {
+        return this.nodes[netID][Math.floor(Math.random() * this.nodes[netID].length)];
+    }
+
+    /**
+    * Reads a specific node from the routing table based on blockchain netID, ip, and port
+    * @param {string} netID - blockchain netID
+    * @param {string} ipPort - Ip and port string ("127.0.0.1:80")
+    */
+    public readNode(netID: string, ipPort: string) {
+        for(let i = 0; i < this.nodes[netID].length; i++) {
+            if (this.nodes[netID][i].ipPort == ipPort) {
+                return this.nodes[netID][i];
+            }
+        }
+        return new Error("Node not found in routing table.");
+    }
+
+    /**
+    * Add a node to the routing table
+    * @param {Node} node - node object to be added
+    */
+    public addNode(node: Node) {
+        this.nodes[node.blockchain.netID] = this.nodes[node.blockchain.netID] || [];
+        this.nodes[node.blockchain.netID].push(node);
+        // If this pushes the count over the maxNodes, splice the first element off
+        if (this.nodes[node.blockchain.netID].length  > this.configuration.maxNodes) {
+            this.nodes[node.blockchain.netID].splice(0, 1);
+        }
+    }
+
+    /**
+    * Deletes a node from the routing table
+    * @param {Node} node - node object to be deleted
+    */
+    public deleteNode(node: Node) {
+        // Cycle through the list of nodes, find a match, splice it off
+        for(let i = 0; i < this.nodes[node.blockchain.netID].length; i++) {
+            if (this.nodes[node.blockchain.netID][i].ipPort == node.ipPort) {
+                this.nodes[node.blockchain.netID].splice(i, 1);
+            }
+        }
+    }
+}

--- a/tests/routing.ts
+++ b/tests/routing.ts
@@ -114,9 +114,8 @@ describe('Routing Table tests',() => {
 
         const routing = new Routing( nodes, pocket.configuration);
         routing.deleteNode(node);
-
-        const readNode = routing.readNode('0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4c');
-        expect(readNode).to.be.an.instanceof(Error);
+        
+        expect(() => routing.readNode('0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4c')).to.throw("Node not found in routing table.");
     }).timeout(0);
 
     it('should not allow more than the max number of nodes per blockchain to be added to the routing table', () => {

--- a/tests/routing.ts
+++ b/tests/routing.ts
@@ -1,0 +1,184 @@
+/**
+ * @author Alex Firmani <alex@pokt.network>
+ * @description Unit tests for the Routing Table
+ */
+// Config
+import * as config from "../config.json";
+// Constants
+import { expect } from 'chai';
+import { Pocket } from '../src/pocket';
+import { Routing } from "../src/models/routing";
+import { Node } from "../src/models/node";
+import { Blockchain } from "../src/models/blockchain";
+
+const DEV_ID = config.dev_id;
+
+describe('Routing Table tests',() => {
+    it('should initialize a routing table', () => {
+        const opts = {
+            devID: DEV_ID,
+            netIDs: [10],
+            networkName: "ETH",
+            requestTimeOut: 40000
+        }
+        const pocket = new Pocket(opts);
+        const blockchain = new Blockchain(pocket.configuration.blockchains[0].name, pocket.configuration.blockchains[0].netID);
+        const node = new Node(blockchain, '127.0.0.1:80');
+        let nodes: Node[] = [node];
+        const routing = new Routing( nodes, pocket.configuration);
+
+        expect(routing).to.be.an.instanceof(Routing);
+    }).timeout(0);
+
+    it('should fail to initialize a routing table due to lack of nodes', () => {
+        const opts = {
+            devID: DEV_ID,
+            netIDs: [10],
+            networkName: "ETH",
+            requestTimeOut: 40000
+        }
+        const pocket = new Pocket(opts);
+        let nodes: Node[] = [];
+
+        expect(() => new Routing(nodes, pocket.configuration)).to.throw("Routing table must be initialized with at least one node.");
+    }).timeout(0);
+
+    it('should fail to initialize a routing table due to excessive nodes', () => {
+        const opts = {
+            devID: DEV_ID,
+            netIDs: [10],
+            networkName: "ETH",
+            requestTimeOut: 40000
+        }
+        const pocket = new Pocket(opts);
+        const blockchain = new Blockchain(pocket.configuration.blockchains[0].name, pocket.configuration.blockchains[0].netID);
+        const node = new Node(blockchain, '127.0.0.1:80');
+
+        let nodes: Node[] = [node];
+        for(let i = 0; i < pocket.configuration.maxNodes; i++) {
+            nodes.push(node);
+        }
+
+        expect(() => new Routing(nodes, pocket.configuration)).to.throw("Routing table cannot contain more than the specified maxNodes per blockchain.");
+    }).timeout(0);
+
+    it('should be able to read a specific node from the routing table', () => {
+        const opts = {
+            devID: DEV_ID,
+            netIDs: [10],
+            networkName: "ETH",
+            requestTimeOut: 40000
+        }
+        const pocket = new Pocket(opts);
+        const blockchain = new Blockchain(pocket.configuration.blockchains[0].name, pocket.configuration.blockchains[0].netID);
+        const node = new Node(blockchain, '127.0.0.1:80');
+        let nodes: Node[] = [node];
+        const routing = new Routing( nodes, pocket.configuration);
+
+        const readNode = routing.readNode(pocket.configuration.blockchains[0].netID, 'http://127.0.0.1:80');
+        expect(readNode).to.be.an.instanceof(Node);
+    }).timeout(0);
+
+    it('should be able to add a node to the routing table', () => {
+        const opts = {
+            devID: DEV_ID,
+            netIDs: [10],
+            networkName: "ETH",
+            requestTimeOut: 40000
+        }
+        const pocket = new Pocket(opts);
+        const blockchain = new Blockchain(pocket.configuration.blockchains[0].name, pocket.configuration.blockchains[0].netID);
+        const node = new Node(blockchain, '127.0.0.1:80');
+        let nodes: Node[] = [node];
+
+        const routing = new Routing( nodes, pocket.configuration);
+        const node2 = new Node(blockchain, '127.0.0.2:80');
+        routing.addNode(node2);
+
+        const readNode = routing.readNode(pocket.configuration.blockchains[0].netID, 'http://127.0.0.2:80');
+        expect(readNode).to.be.an.instanceof(Node);
+    }).timeout(0);
+
+    it('should be able to delete a node from the routing table', () => {
+        const opts = {
+            devID: DEV_ID,
+            netIDs: [10],
+            networkName: "ETH",
+            requestTimeOut: 40000
+        }
+        const pocket = new Pocket(opts);
+        const blockchain = new Blockchain(pocket.configuration.blockchains[0].name, pocket.configuration.blockchains[0].netID);
+        const node = new Node(blockchain, '127.0.0.1:80');
+        let nodes: Node[] = [node];
+
+        const routing = new Routing( nodes, pocket.configuration);
+        routing.deleteNode(node);
+
+        const readNode = routing.readNode(pocket.configuration.blockchains[0].netID, 'http://127.0.0.1:80');
+        expect(readNode).to.be.an.instanceof(Error);
+    }).timeout(0);
+
+    it('should not allow more than the max number of nodes per blockchain to be added to the routing table', () => {
+        const opts = {
+            devID: DEV_ID,
+            netIDs: [10],
+            networkName: "ETH",
+            requestTimeOut: 40000
+        }
+        const pocket = new Pocket(opts);
+        const blockchain = new Blockchain(pocket.configuration.blockchains[0].name, pocket.configuration.blockchains[0].netID);
+        const node = new Node(blockchain, '127.0.0.1:80');
+        let nodes: Node[] = [node];
+
+        const routing = new Routing( nodes, pocket.configuration);
+        // Add more than the currently allowed since one was added already above
+        for(let i = 0; i < pocket.configuration.maxNodes; i++) {
+            routing.addNode(node);
+        }
+        expect(routing.nodes[pocket.configuration.blockchains[0].netID].length).to.lte(pocket.configuration.maxNodes);
+    }).timeout(0);
+
+    it('should be able to read a random node from the routing table', () => {
+        const opts = {
+            devID: DEV_ID,
+            netIDs: [10],
+            networkName: "ETH",
+            requestTimeOut: 40000
+        }
+        const pocket = new Pocket(opts);
+        const blockchain = new Blockchain(pocket.configuration.blockchains[0].name, pocket.configuration.blockchains[0].netID);
+        const node = new Node(blockchain, '127.0.0.1:80');
+        let nodes: Node[] = [node];
+        const routing = new Routing( nodes, pocket.configuration);
+
+        const readNode = routing.readRandomNode(pocket.configuration.blockchains[0].netID);
+        expect(readNode).to.be.an.instanceof(Node);
+    }).timeout(0);
+
+    it('should be able to read multiple random nodes from the routing table', () => { // Test doesn't currently check randomness of results
+        const opts = {
+            devID: DEV_ID,
+            netIDs: [10],
+            networkName: "ETH",
+            requestTimeOut: 40000
+        }
+        const pocket = new Pocket(opts);
+        const blockchain = new Blockchain(pocket.configuration.blockchains[0].name, pocket.configuration.blockchains[0].netID);
+
+        const node = new Node(blockchain, '127.0.0.1:80');
+        let nodes: Node[] = [node];
+        const routing = new Routing( nodes, pocket.configuration);
+
+        for(let i = 2; i <= pocket.configuration.maxNodes; i++) {
+            let node = new Node(blockchain, '127.0.0.' + i + ':80');
+            routing.addNode(node);
+        }
+
+        const readNodes = routing.readRandomNodes(pocket.configuration.blockchains[0].netID, 3);
+
+        expect(readNodes[0]).to.be.an.instanceof(Node);
+        expect(readNodes[1]).to.be.an.instanceof(Node);
+        expect(readNodes[2]).to.be.an.instanceof(Node);
+    }).timeout(0);
+
+}).timeout(0);

--- a/tests/routing.ts
+++ b/tests/routing.ts
@@ -23,8 +23,8 @@ describe('Routing Table tests',() => {
         }
         const pocket = new Pocket(opts);
         const blockchain = new Blockchain(pocket.configuration.blockchains[0].name, pocket.configuration.blockchains[0].netID);
-        const node = new Node(blockchain, '127.0.0.1:80');
-        let nodes: Node[] = [node];
+        const node = new Node(blockchain, '127.0.0.1:80', '0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4c');
+        const nodes: Node[] = [node];
         const routing = new Routing( nodes, pocket.configuration);
 
         expect(routing).to.be.an.instanceof(Routing);
@@ -38,7 +38,7 @@ describe('Routing Table tests',() => {
             requestTimeOut: 40000
         }
         const pocket = new Pocket(opts);
-        let nodes: Node[] = [];
+        const nodes: Node[] = [];
 
         expect(() => new Routing(nodes, pocket.configuration)).to.throw("Routing table must be initialized with at least one node.");
     }).timeout(0);
@@ -52,11 +52,12 @@ describe('Routing Table tests',() => {
         }
         const pocket = new Pocket(opts);
         const blockchain = new Blockchain(pocket.configuration.blockchains[0].name, pocket.configuration.blockchains[0].netID);
-        const node = new Node(blockchain, '127.0.0.1:80');
+        const node = new Node(blockchain, '127.0.0.1:80', '0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4c');
 
-        let nodes: Node[] = [node];
+        const nodes: Node[] = [node];
         for(let i = 0; i < pocket.configuration.maxNodes; i++) {
-            nodes.push(node);
+            const secondaryNode = new Node(blockchain, '127.0.0.' + i + ':80', '0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4' + i);
+            nodes.push(secondaryNode);
         }
 
         expect(() => new Routing(nodes, pocket.configuration)).to.throw("Routing table cannot contain more than the specified maxNodes per blockchain.");
@@ -71,11 +72,11 @@ describe('Routing Table tests',() => {
         }
         const pocket = new Pocket(opts);
         const blockchain = new Blockchain(pocket.configuration.blockchains[0].name, pocket.configuration.blockchains[0].netID);
-        const node = new Node(blockchain, '127.0.0.1:80');
-        let nodes: Node[] = [node];
+        const node = new Node(blockchain, '127.0.0.1:80', '0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4c');
+        const nodes: Node[] = [node];
         const routing = new Routing( nodes, pocket.configuration);
 
-        const readNode = routing.readNode(pocket.configuration.blockchains[0].netID, 'http://127.0.0.1:80');
+        const readNode = routing.readNode('0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4c');
         expect(readNode).to.be.an.instanceof(Node);
     }).timeout(0);
 
@@ -88,14 +89,14 @@ describe('Routing Table tests',() => {
         }
         const pocket = new Pocket(opts);
         const blockchain = new Blockchain(pocket.configuration.blockchains[0].name, pocket.configuration.blockchains[0].netID);
-        const node = new Node(blockchain, '127.0.0.1:80');
-        let nodes: Node[] = [node];
+        const node = new Node(blockchain, '127.0.0.1:80', '0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4c');
+        const nodes: Node[] = [node];
 
         const routing = new Routing( nodes, pocket.configuration);
-        const node2 = new Node(blockchain, '127.0.0.2:80');
-        routing.addNode(node2);
+        const secondaryNode = new Node(blockchain, '127.0.0.2:80', '0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4d');
+        routing.addNode(secondaryNode);
 
-        const readNode = routing.readNode(pocket.configuration.blockchains[0].netID, 'http://127.0.0.2:80');
+        const readNode = routing.readNode('0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4c');
         expect(readNode).to.be.an.instanceof(Node);
     }).timeout(0);
 
@@ -108,13 +109,13 @@ describe('Routing Table tests',() => {
         }
         const pocket = new Pocket(opts);
         const blockchain = new Blockchain(pocket.configuration.blockchains[0].name, pocket.configuration.blockchains[0].netID);
-        const node = new Node(blockchain, '127.0.0.1:80');
-        let nodes: Node[] = [node];
+        const node = new Node(blockchain, '127.0.0.1:80', '0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4c');
+        const nodes: Node[] = [node];
 
         const routing = new Routing( nodes, pocket.configuration);
         routing.deleteNode(node);
 
-        const readNode = routing.readNode(pocket.configuration.blockchains[0].netID, 'http://127.0.0.1:80');
+        const readNode = routing.readNode('0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4c');
         expect(readNode).to.be.an.instanceof(Error);
     }).timeout(0);
 
@@ -127,15 +128,16 @@ describe('Routing Table tests',() => {
         }
         const pocket = new Pocket(opts);
         const blockchain = new Blockchain(pocket.configuration.blockchains[0].name, pocket.configuration.blockchains[0].netID);
-        const node = new Node(blockchain, '127.0.0.1:80');
-        let nodes: Node[] = [node];
+        const node = new Node(blockchain, '127.0.0.1:80', '0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4c');
+        const nodes: Node[] = [node];
 
         const routing = new Routing( nodes, pocket.configuration);
         // Add more than the currently allowed since one was added already above
         for(let i = 0; i < pocket.configuration.maxNodes; i++) {
-            routing.addNode(node);
+            const secondaryNode = new Node(blockchain, '127.0.0.' + i + ':80', '0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4' + i);
+            routing.addNode(secondaryNode);
         }
-        expect(routing.nodes[pocket.configuration.blockchains[0].netID].length).to.lte(pocket.configuration.maxNodes);
+        expect(routing.nodes.length).to.lte(pocket.configuration.maxNodes);
     }).timeout(0);
 
     it('should be able to read a random node from the routing table', () => {
@@ -147,11 +149,11 @@ describe('Routing Table tests',() => {
         }
         const pocket = new Pocket(opts);
         const blockchain = new Blockchain(pocket.configuration.blockchains[0].name, pocket.configuration.blockchains[0].netID);
-        const node = new Node(blockchain, '127.0.0.1:80');
-        let nodes: Node[] = [node];
+        const node = new Node(blockchain, '127.0.0.1:80', '0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4c');
+        const nodes: Node[] = [node];
         const routing = new Routing( nodes, pocket.configuration);
 
-        const readNode = routing.readRandomNode(pocket.configuration.blockchains[0].netID);
+        const readNode = routing.readRandomNode();
         expect(readNode).to.be.an.instanceof(Node);
     }).timeout(0);
 
@@ -165,16 +167,16 @@ describe('Routing Table tests',() => {
         const pocket = new Pocket(opts);
         const blockchain = new Blockchain(pocket.configuration.blockchains[0].name, pocket.configuration.blockchains[0].netID);
 
-        const node = new Node(blockchain, '127.0.0.1:80');
-        let nodes: Node[] = [node];
+        const node = new Node(blockchain, '127.0.0.1:80', '0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4c');
+        const nodes: Node[] = [node];
         const routing = new Routing( nodes, pocket.configuration);
 
         for(let i = 2; i <= pocket.configuration.maxNodes; i++) {
-            let node = new Node(blockchain, '127.0.0.' + i + ':80');
-            routing.addNode(node);
+            const secondaryNode = new Node(blockchain, '127.0.0.' + i + ':80', '0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4' + i);
+            routing.addNode(secondaryNode);
         }
 
-        const readNodes = routing.readRandomNodes(pocket.configuration.blockchains[0].netID, 3);
+        const readNodes = routing.readRandomNodes(3);
 
         expect(readNodes[0]).to.be.an.instanceof(Node);
         expect(readNodes[1]).to.be.an.instanceof(Node);


### PR DESCRIPTION
One assumption was made: that "maxNodes" should be on a per blockchain basis.

Nodes are stored in a dictionary based on their netID and are limited to the maxNodes per netID.