### PR TITLE
Correcting comment type from AAT to string

### DIFF
--- a/src/models/proof.ts
+++ b/src/models/proof.ts
@@ -39,7 +39,7 @@ export class Proof {
      * @param {BigInt} sessionBlockHeight - Session Block Height.
      * @param {String} servicePubKey - Service Public Key.
      * @param {String} blockchain - Blockchain hash.
-     * @param {AAT} token - Application Authentication Token.
+     * @param {String} token - Application Authentication Token.
      * @param {String} signature - Proof's signature.
      */
     constructor(


### PR DESCRIPTION
Comment said type was AAT -- but type AAT doesn't exist. Actual function takes in String.