### PR TITLE
attempting to fix session not found error

### DIFF
--- a/src/session/session-manager.ts
+++ b/src/session/session-manager.ts
@@ -127,9 +127,9 @@ export class SessionManager {
       } else {
         return currentSession
       }
+    } else {
+      return await this.requestCurrentSession(pocketAAT, chain, configuration, sessionBlockHeight)
     }
-
-    return new RpcError("500", "Session not found")
   }
 
   /**


### PR DESCRIPTION
PR creates failure path in session manager for a session key with an empty but defined key. I can see no reason it should throw a 500 at that point rather than try and request a new session.