### PR TITLE
Session refresh mechanism

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,3 +1,6 @@
+## 0.6.1-RC
+- Fixed session refresh mechanism
+
 ## 0.6.0-RC
 - Updated dependencies
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@pokt-network/pocket-js",
-    "version": "0.6.0-rc",
+    "version": "0.6.1-rc",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pokt-network/pocket-js",
-    "version": "0.6.0-rc",
+    "version": "0.6.1-rc",
     "engine": {
         "node": ">=10.19.0 <=12.15.0"
     },

--- a/src/pocket.ts
+++ b/src/pocket.ts
@@ -287,6 +287,7 @@ export class Pocket {
       // Check session out of sync error
       if (typeGuard(result, RpcError)) {
         const rpcError = result as RpcError
+        console.log("initial error")
         console.log(rpcError)
         // Refresh the current session if we get this error code
         if (
@@ -299,16 +300,26 @@ export class Pocket {
             console.log("retrying session")
             // Get the current session
             const currentSessionOrError = await this.sessionManager.requestCurrentSession(pocketAAT, blockchain, configuration)
+            console.log("currentSessionOrError")
+            console.log(currentSessionOrError)
             if (typeGuard(currentSessionOrError, RpcError)) {
               // If error or same session, don't even retry relay
+              console.log("got rpcerror")
               continue
             } else if (typeGuard(currentSessionOrError, Session)) {
               const newSession = currentSessionOrError as Session
+              console.log("got session")
+              console.log(newSession)
               if (newSession.sessionHeader.sessionBlockHeight === currentSessionOrError.sessionHeader.sessionBlockHeight) {
                 // If we get the same session skip this attempt
+                console.log("nsb")
+                console.log(newSession.sessionHeader.sessionBlockHeight)
+                console.log("csb")
+                console.log(newSession.sessionHeader.sessionBlockHeight)
                 continue
               }
             }
+            console.log("refreshed")
             sessionRefreshed = true
             break
           }
@@ -316,11 +327,14 @@ export class Pocket {
           if (sessionRefreshed) {
             // If a new session is succesfully obtained retry the relay
             // This won't cause an endless loop because the relay will only be retried only if the session was refreshed
+            console.log("relay again")
             return this.sendRelay(data, blockchain, pocketAAT, configuration, headers, method, path, node, consensusEnabled)
           } else {
+            console.log("return error 1")
             return rpcError
           }
         } else {
+          console.log("return error 2")
           return rpcError
         }
       } else if (consensusEnabled && typeGuard(result, RelayResponse)) {
@@ -330,9 +344,11 @@ export class Pocket {
         }
         return new ConsensusNode(serviceNode, false, result)
       } else {
+        console.log("return result 3")
         return result
       }
     } catch (error) {
+      console.log("caught error")
       return RpcError.fromError(error)
     }
   }

--- a/src/pocket.ts
+++ b/src/pocket.ts
@@ -304,7 +304,7 @@ export class Pocket {
               continue
             } else if (typeGuard(currentSessionOrError, Session)) {
               const newSession = currentSessionOrError as Session
-              if (newSession.sessionKey === currentSessionOrError.sessionKey) {
+              if (newSession.sessionHeader.sessionBlockHeight === currentSessionOrError.sessionHeader.sessionBlockHeight) {
                 // If we get the same session skip this attempt
                 continue
               }

--- a/src/pocket.ts
+++ b/src/pocket.ts
@@ -280,12 +280,14 @@ export class Pocket {
 
       // Relay to be sent
       const relay = new RelayRequest(relayPayload, relayMeta, relayProof)
+      console.log(relayMeta)
       // Send relay
       const result = await rpc.client.relay(relay, configuration.validateRelayResponses, configuration.requestTimeOut, configuration.rejectSelfSignedCertificates)
 
       // Check session out of sync error
       if (typeGuard(result, RpcError)) {
         const rpcError = result as RpcError
+        console.log(rpcError)
         // Refresh the current session if we get this error code
         if (
           rpcError.code === "60" // InvalidBlockHeightError = errors.New("the block height passed is invalid")
@@ -294,6 +296,7 @@ export class Pocket {
         ) {
           let sessionRefreshed = false
           for (let retryIndex = 0; retryIndex < configuration.maxSessionRefreshRetries; retryIndex++) {
+            console.log("retrying session")
             // Get the current session
             const currentSessionOrError = await this.sessionManager.requestCurrentSession(pocketAAT, blockchain, configuration)
             if (typeGuard(currentSessionOrError, RpcError)) {

--- a/src/pocket.ts
+++ b/src/pocket.ts
@@ -310,12 +310,12 @@ export class Pocket {
               const newSession = currentSessionOrError as Session
               console.log("got session")
               console.log(newSession)
-              if (newSession.sessionHeader.sessionBlockHeight === currentSessionOrError.sessionHeader.sessionBlockHeight) {
+              if (newSession.sessionHeader.sessionBlockHeight === currentSession.sessionHeader.sessionBlockHeight) {
                 // If we get the same session skip this attempt
                 console.log("nsb")
                 console.log(newSession.sessionHeader.sessionBlockHeight)
                 console.log("csb")
-                console.log(newSession.sessionHeader.sessionBlockHeight)
+                console.log(currentSession.sessionHeader.sessionBlockHeight)
                 continue
               }
             }

--- a/src/rpc/models/input/session-header.ts
+++ b/src/rpc/models/input/session-header.ts
@@ -35,7 +35,6 @@ export class SessionHeader {
    * @param {string} applicationPubKey - Application Key associated with a client.
    * @param {string} chain - Chain.
    * @param {BigInt} sessionBlockHeight - Height of session.
-   * @param {number} sessionTimestamp - Creation timestamp, used locally only.
    */
   constructor(
     applicationPubKey: string,

--- a/src/rpc/models/output/session.ts
+++ b/src/rpc/models/output/session.ts
@@ -1,6 +1,5 @@
 import { Node } from "../node"
 import { SessionHeader } from "../input/session-header"
-import { Configuration } from "../../../config/configuration"
 
 /**
  *
@@ -17,11 +16,6 @@ export class Session {
    */
   public static fromJSON(json: string): Session {
     const jsonObject = JSON.parse(json)
-
-    // Compute the session timestamp from the number of blocks since dispatch
-    const sessionBlockAge = Number( BigInt(jsonObject.block_height) - BigInt(jsonObject.session.header.session_height))
-    jsonObject.session.header.session_timestamp = Math.floor( (Date.now() / 1000) - (sessionBlockAge * 60))
-    
     const sessionHeader = SessionHeader.fromJSON(JSON.stringify(jsonObject.session.header))
     const sessionNodes: Node[] = []
 

--- a/src/session/session-manager.ts
+++ b/src/session/session-manager.ts
@@ -71,9 +71,9 @@ export class SessionManager {
     const rpc = new RPC(new HttpRpcProvider(dispatcher))
     const header = new SessionHeader(pocketAAT.applicationPublicKey, chain, BigInt(0))
     const dispatchRequest: DispatchRequest = new DispatchRequest(header)
-    console.log(dispatchRequest)
+
     const result = await rpc.client.dispatch(dispatchRequest, configuration.requestTimeOut, configuration.rejectSelfSignedCertificates)
-    console.log(result)
+
     if (typeGuard(result, DispatchResponse)) {
       let session: Session
       try {
@@ -86,7 +86,6 @@ export class SessionManager {
 
       if (session !== undefined) {
         const key = this.getSessionKey(pocketAAT, chain)
-        console.log('saving session')
         return this.saveSession(key, session, configuration)
       } else {
         return new RpcError(

--- a/src/session/session-manager.ts
+++ b/src/session/session-manager.ts
@@ -71,8 +71,9 @@ export class SessionManager {
     const rpc = new RPC(new HttpRpcProvider(dispatcher))
     const header = new SessionHeader(pocketAAT.applicationPublicKey, chain, BigInt(0))
     const dispatchRequest: DispatchRequest = new DispatchRequest(header)
+    console.log(dispatchRequest)
     const result = await rpc.client.dispatch(dispatchRequest, configuration.requestTimeOut, configuration.rejectSelfSignedCertificates)
-
+    console.log(result)
     if (typeGuard(result, DispatchResponse)) {
       let session: Session
       try {
@@ -85,6 +86,7 @@ export class SessionManager {
 
       if (session !== undefined) {
         const key = this.getSessionKey(pocketAAT, chain)
+        console.log('saving session')
         return this.saveSession(key, session, configuration)
       } else {
         return new RpcError(


### PR DESCRIPTION
Bugs fixed:

- wrong comparison to see if the new session returned from dispatch was the same as the old session (two bugs, was using sessionKey that never changes and it was comparing the same object to itself)

- refresh mechanism never destroyed the old session so while it was fetching a new session, it was getting stuck on the end of the queue with the old outdated session still intact at the front of the queue. As a result, the new fresh session was never used.