### PR TITLE
Package 0.6.4-rc

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,3 +1,6 @@
+## 0.6.4-RC
+- Updated RPC Call getBlock to support pocket-core Beta-0.5.2.x.
+  
 ## 0.6.3-RC
 - Fixed query AccountTxs failing to parse sent txs response for some scenarios.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pokt-network/pocket-js",
-    "version": "0.6.3-rc",
+    "version": "0.6.4-rc",
     "engine": {
         "node": ">=10.19.0 <=12.15.0"
     },

--- a/src/rpc/models/output/query-block-response.ts
+++ b/src/rpc/models/output/query-block-response.ts
@@ -17,9 +17,14 @@ export class QueryBlockResponse {
   public static fromJSON(json: string): QueryBlockResponse {
     try {
       const jsonObject = JSON.parse(json)
-    
+      
+      const blockMeta = jsonObject.block_meta !== undefined ? jsonObject.block_meta : {
+        block_id: jsonObject.block_id,
+        header: jsonObject.block.header
+      }
+
       return new QueryBlockResponse(
-        BlockMeta.fromJSON(JSON.stringify(jsonObject.block_meta)),
+        BlockMeta.fromJSON(JSON.stringify(blockMeta)),
         Block.fromJSON(JSON.stringify(jsonObject.block))
       )
     } catch (error) {


### PR DESCRIPTION
updated getBlock rpc call to support latest pocket-core 0.5.2.x beta versions, updated package version to 0.6.4-rc