### PR TITLE
Feature: separate and expose the raw transaction processing logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pokt-network/pocket-js",
-    "version": "0.6.9-rc",
+    "version": "0.6.10-rc",
     "engine": {
         "node": ">=10.19.0 <=12.15.0"
     },


### PR DESCRIPTION
## Overview
**Version**: 0.6.10-rc
**Summary**: Segregate and Expose Raw Transactions Logic.

## Description

In this pr, we isolate the logic that goes into signing the raw transaction before submitting in a separate public method named `process` that is subsequently used by `submit`. This does not break the API whatsover.

## Why?

In our attempt to implement QoS Control for the Wallet by relaying all of the RPC requests that go to pocket through the gateway, we came across the `rawTx` client query. At first glance, we thought we'd duplicate the processing logic, but maintaining two versions of a non-trivial signature logic that requires > 5 complex models (_signature docs, standard and what not, with support for two rpc codecs_) is a bad idea, so we decided (_or I_) to go with this approach.

Wallet code changes as follows:

**Instead of**:
```
    const sendRawTxResponse = await transactionSenderOrError
      .send(accountOrUndefined.addressHex, toAddress, amount.toString())
      .submit(Config.CHAIN_ID, defaultFee.toString(), CoinDenom.Upokt, "Pocket Wallet");
```

**We do**:
```

    const rawTxPayload = await transactionSenderOrError
      .send(accountOrUndefined.addressHex, toAddress, amount.toString())
      .process(Config.CHAIN_ID, defaultFee.toString(), CoinDenom.Upokt, "Pocket Wallet");

   // send it over the gateway
```

And voila!

**This guarantees that no fork shall be underwent when it comes to processing raw transactions.**

## References

The concerned pull request: [Wallet Pull request](https://github.com/pokt-network/pocket-wallet/pull/149)