### PR TITLE
Fix dispatchers permanently deleted on failure

### DIFF
--- a/src/routing-table/routing-table.ts
+++ b/src/routing-table/routing-table.ts
@@ -135,26 +135,4 @@ export class RoutingTable {
     this.store.add(this.dispatchersKey, dispatchers)
     return true
   }
-
-  /**
-   * Deletes a dispatcher url from the routing table
-   * @param {URL} url - url object to be deleted
-   * @returns {boolean} True or false if the node was deleted.
-   * @memberof Routing
-   */
-  public deleteDispatcher(url: URL): boolean {
-    // Cycle through the list of nodes, find a match, splice it off
-    const dispatchers = this.store.get(this.dispatchersKey) as URL[]
-
-    for (let i = 0; i < dispatchers.length; i++) {
-      if (dispatchers[i].host === url.host) {
-        dispatchers.splice(i, 1)
-
-        // Update the store
-        this.store.add(this.dispatchersKey, dispatchers)
-        return true
-      }
-    }
-    return false
-  }
 }


### PR DESCRIPTION
Closes #429 

This fix changes the behavior of the session creation by retrying all the dispatchers at least twice (randomly so a dispatcher might be tested more than twice) and giving up only after failure from the behavior before

Also, the dispatchers are not deleted permanently anymore so there will be no need to restart the client either