### PR TITLE
feat: transaction deserialization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@pokt-network/pocket-js",
-    "version": "0.6.17-rc",
+    "version": "0.7.1-rc",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@pokt-network/pocket-js",
-            "version": "0.6.17-rc",
+            "version": "0.7.1-rc",
             "license": "MIT",
             "dependencies": {
                 "@pokt-network/aat-js": "0.1.3-rc",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@pokt-network/pocket-js",
-    "version": "0.6.13-rc",
+    "version": "0.6.17-rc",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pokt-network/pocket-js",
-    "version": "0.7.0-rc",
+    "version": "0.7.1-rc",
     "engine": {
         "node": ">=12.16.0 <=16.13.0"
     },

--- a/src/pocket.ts
+++ b/src/pocket.ts
@@ -16,6 +16,7 @@ import { RelayMeta } from "./rpc/models/input/relay-meta"
 import { BaseProfiler } from "./utils/base-profiler"
 import { ProfileResult } from "./utils/models/profile-result"
 import { NoOpProfiler } from "./utils/no-op-profiler"
+import { ProtoTxDecoder } from "./transactions/factory/proto-tx-decoder"
 
 /**
  *
@@ -167,7 +168,7 @@ export class Pocket {
         return new RpcError("NA", "Failed to send a consensus relay due to false consensus result, not acepting disputed responses without proper majority and minority responses.")
       }
     } catch (err) {
-      return RpcError.fromError(err)
+      return RpcError.fromError(err as Error)
     }
   }
   /**
@@ -279,7 +280,7 @@ export class Pocket {
       }
 
       // Produce signature payload
-      const relayMeta = new RelayMeta(BigInt(currentSession.sessionHeader.sessionBlockHeight))
+      const relayMeta = new RelayMeta(currentSession.sessionHeader.sessionBlockHeight)
       const requestHash = new RequestHash(relayPayload, relayMeta)
       const entropy = BigInt(Math.floor(Math.random() * 99999999999999999))
       // Profiler
@@ -450,7 +451,7 @@ export class Pocket {
         return result
       }
     } catch (error) {
-      return RpcError.fromError(error)
+      return RpcError.fromError(error as Error)
     }
   }
 
@@ -470,7 +471,7 @@ export class Pocket {
       const unlockedAccount = new UnlockedAccount(new Account(pubKey, ''), privKeyBuffer)
       return new TransactionSender(this, unlockedAccount)
     } catch (err) {
-      return err
+      return err as Error
     }
   }
 
@@ -503,9 +504,19 @@ export class Pocket {
     try {
       return new TransactionSender(this, undefined, txSigner)
     } catch (err) {
-      return err
+      return err as Error
     }
   }
+
+  public withProtoTxDecoder(): ProtoTxDecoder | Error {
+    try {
+      return new ProtoTxDecoder()
+    } catch (err) {
+      return err as Error
+    }
+  }
+
+  
 }
 
 export * from "@pokt-network/aat-js"

--- a/src/pocket.ts
+++ b/src/pocket.ts
@@ -165,7 +165,7 @@ export class Pocket {
         }
         return challengeResponseOrError
       } else {
-        return new RpcError("NA", "Failed to send a consensus relay due to false consensus result, not acepting disputed responses without proper majority and minority responses.")
+        return new RpcError("NA", "Failed to send a consensus relay due to false consensus result, not accepting disputed responses without proper majority and minority responses.")
       }
     } catch (err) {
       return RpcError.fromError(err as Error)

--- a/src/transactions/factory/index.ts
+++ b/src/transactions/factory/index.ts
@@ -1,4 +1,5 @@
 export * from './amino-tx-encoder'
 export * from './base-tx-encoder'
+export * from './proto-tx-decoder'
 export * from './proto-tx-encoder'
 export * from './tx-encoder-factory'

--- a/src/transactions/factory/proto-tx-decoder.ts
+++ b/src/transactions/factory/proto-tx-decoder.ts
@@ -1,0 +1,38 @@
+import { MsgSend, ProtoStdTx } from '../models/proto/generated/tx-signer'
+
+export class ProtoTxDecoder {
+    // Returns partially decoded transaction
+    public unmarshalStdTx(encodedTxBytes: Buffer, length: number = encodedTxBytes.length): ProtoStdTx {
+        return ProtoStdTx.decode(encodedTxBytes.subarray(2), length - 2)
+    }
+
+    // Returns decoded transaction message data
+    public decodeStdTxData(protoStdTx: ProtoStdTx) {
+        switch(protoStdTx.msg?.typeUrl) {
+            case '/x.nodes.MsgSend':
+                const msgSendData = MsgSend.decode(protoStdTx.msg.value)
+
+                const decodedStdTxData = {
+                    memo: protoStdTx.memo,
+                    entropy: protoStdTx.entropy,
+                    fee: protoStdTx.fee,
+                    msg: {
+                        typeUrl: protoStdTx.msg.typeUrl,
+                        value: {
+                            amount: msgSendData.amount,
+                            FromAddress: Buffer.from(msgSendData.FromAddress).toString('hex'),
+                            ToAddress: Buffer.from(msgSendData.ToAddress).toString('hex') 
+                        }
+                    },
+                    signature: protoStdTx.signature ? {
+                        publicKey: Buffer.from(protoStdTx.signature.publicKey).toString('hex'),
+                        Signature: Buffer.from(protoStdTx.signature.Signature).toString('hex')
+                    } : protoStdTx.signature
+                }
+                
+                return decodedStdTxData
+            default:
+                throw Error('Decoding for transaction type not supported yet.')
+        }
+    }
+}

--- a/src/transactions/factory/proto-tx-encoder.ts
+++ b/src/transactions/factory/proto-tx-encoder.ts
@@ -1,10 +1,7 @@
-import { typeGuard } from '../../utils'
-import { RpcError } from '../../rpc'
 import { TxSignature } from '../models/tx-signature'
 import { CoinDenom } from '../models/coin-denom'
-import { TxMsg } from '../models'
 import { BaseTxEncoder } from './base-tx-encoder'
-import { Coin, ProtoStdSignature, ProtoStdTx } from '../models/proto/generated/tx-signer'
+import { ProtoStdSignature, ProtoStdTx } from '../models/proto/generated/tx-signer'
 import * as varint from "varint"
 
 export class ProtoTxEncoder extends BaseTxEncoder {

--- a/src/transactions/models/proto/generated/tx-signer.ts
+++ b/src/transactions/models/proto/generated/tx-signer.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import * as Long from "long";
+import Long from "long";
 import { util, configure, Writer, Reader } from "protobufjs/minimal";
 import { Any } from "./google/protobuf/any";
 

--- a/src/transactions/transaction-sender.ts
+++ b/src/transactions/transaction-sender.ts
@@ -86,7 +86,7 @@ export class TransactionSender implements ITransactionSender {
             const txRequest = new RawTxRequest(addressHex.toString("hex"), encodedTxBytes.toString("hex"))
             return txRequest
         } catch (error) {
-            return RpcError.fromError(error)
+            return RpcError.fromError(error as Error)
         }
     }
 
@@ -122,7 +122,7 @@ export class TransactionSender implements ITransactionSender {
 
             return response
         } catch (error) {
-            return RpcError.fromError(error)
+            return RpcError.fromError(error as Error)
         }
     }
 
@@ -145,7 +145,7 @@ export class TransactionSender implements ITransactionSender {
             else
                 this.txMsg = new MsgProtoSend(fromAddress, toAddress, amount)
         } catch (error) {
-            this.txMsgError = error
+            this.txMsgError = error as Error
         }
         return this
     }
@@ -169,7 +169,7 @@ export class TransactionSender implements ITransactionSender {
             else
                 this.txMsg = new MsgProtoAppStake(Buffer.from(appPubKey, "hex"), chains, amount)
         } catch (error) {
-            this.txMsgError = error
+            this.txMsgError = error as Error
         }
         return this
     }
@@ -189,7 +189,7 @@ export class TransactionSender implements ITransactionSender {
             else
                 this.txMsg = new MsgProtoAppUnstake(address)
         } catch (error) {
-            this.txMsgError = error
+            this.txMsgError = error as Error
         }
         return this
     }
@@ -209,7 +209,7 @@ export class TransactionSender implements ITransactionSender {
             else
                 this.txMsg = new MsgProtoAppUnjail(address)
         } catch (error) {
-            this.txMsgError = error
+            this.txMsgError = error as Error
         }
         return this
     }
@@ -236,7 +236,7 @@ export class TransactionSender implements ITransactionSender {
             else
                 this.txMsg = new MsgProtoNodeStakeTx(Buffer.from(nodePubKey, "hex"), chains, amount, serviceURL)
         } catch (error) {
-            this.txMsgError = error
+            this.txMsgError = error as Error
         }
         return this
     }
@@ -256,7 +256,7 @@ export class TransactionSender implements ITransactionSender {
             else
                 this.txMsg = new MsgProtoNodeUnstake(address)
         } catch (error) {
-            this.txMsgError = error
+            this.txMsgError = error as Error
         }
         return this
     }
@@ -277,7 +277,7 @@ export class TransactionSender implements ITransactionSender {
             else
                 this.txMsg = new MsgProtoNodeUnjail(address)
         } catch (error) {
-            this.txMsgError = error
+            this.txMsgError = error as Error
         }
         return this
     }


### PR DESCRIPTION
Adds a Proto Transaction Deserialization Feature. You can now provide a `txHex` and get back the decoded message value.

IMPORTANT: this only works for `Send` transactions as of now.

```javascript
const { ProtoTxDecoder } = require('@pokt-network/pocket-js')

const ENCODED_TX_BYTES = Buffer.from('d1010a4....bf8970d', 'hex')

const protoTxDecoder = await pocket.withProtoTxDecoder()

const protoStdTx = await protoTxDecoder.unmarshalStdTx(ENCODED_TX_BYTES)
  
const data = await protoTxDecoder.decodeStdTxData(protoStdTx)

console.log('Deserialized transaction:', data)
```