### PR TITLE
feat: create transactions with existing signature

### DIFF
--- a/src/transactions/transaction-sender.ts
+++ b/src/transactions/transaction-sender.ts
@@ -75,13 +75,13 @@ export class TransactionSender implements ITransactionSender {
                 } else {
                     return new RpcError("0", "No account or TransactionSigner specified")
                 }
-    
-                if (!typeGuard(txSignature, TxSignature)) {
-                    return new RpcError("0", "Error generating signature for transaction")
-                }
             }
 
             txSignature = signature as TxSignature
+
+            if (!typeGuard(txSignature, TxSignature)) {
+                return new RpcError("0", "Error generating signature for transaction")
+            }
 
             const addressHex = addressFromPublickey(txSignature.pubKey)
             const encodedTxBytes = signer.marshalStdTx(txSignature)

--- a/src/transactions/transaction-sender.ts
+++ b/src/transactions/transaction-sender.ts
@@ -46,7 +46,8 @@ export class TransactionSender implements ITransactionSender {
         chainID: string,
         fee: string,
         feeDenom?: CoinDenom,
-        memo?: string
+        memo?: string,
+        signature?: TxSignature
     ): Promise<RawTxRequest | RpcError> {
         try {
             if (this.txMsgError !== undefined) {
@@ -62,21 +63,26 @@ export class TransactionSender implements ITransactionSender {
 
             const entropy = Number(BigInt(Math.floor(Math.random() * Number.MAX_SAFE_INTEGER)).toString()).toString()
             const signer = TxEncoderFactory.createEncoder(entropy, chainID, this.txMsg, fee, feeDenom, memo, this.pocket.configuration.useLegacyTxCodec)
-            let txSignatureOrError
-            const bytesToSign = signer.marshalStdSignDoc()
-            if (typeGuard(this.unlockedAccount, UnlockedAccount)) {
-                txSignatureOrError = await this.signWithUnlockedAccount(bytesToSign, this.unlockedAccount as UnlockedAccount)
-            } else if (this.txSigner !== undefined) {
-                txSignatureOrError = this.signWithTrasactionSigner(bytesToSign, this.txSigner as TransactionSigner)
-            } else {
-                return new RpcError("0", "No account or TransactionSigner specified")
+            
+            let txSignature
+
+            if (!signature) {
+                const bytesToSign = signer.marshalStdSignDoc()
+                if (typeGuard(this.unlockedAccount, UnlockedAccount)) {
+                    txSignature = await this.signWithUnlockedAccount(bytesToSign, this.unlockedAccount as UnlockedAccount)
+                } else if (this.txSigner !== undefined) {
+                    txSignature = this.signWithTrasactionSigner(bytesToSign, this.txSigner as TransactionSigner)
+                } else {
+                    return new RpcError("0", "No account or TransactionSigner specified")
+                }
+    
+                if (!typeGuard(txSignature, TxSignature)) {
+                    return new RpcError("0", "Error generating signature for transaction")
+                }
             }
 
-            if (!typeGuard(txSignatureOrError, TxSignature)) {
-                return new RpcError("0", "Error generating signature for transaction")
-            }
+            txSignature = signature as TxSignature
 
-            const txSignature = txSignatureOrError as TxSignature
             const addressHex = addressFromPublickey(txSignature.pubKey)
             const encodedTxBytes = signer.marshalStdTx(txSignature)
             // Clean message and error

--- a/src/transactions/transaction-sender.ts
+++ b/src/transactions/transaction-sender.ts
@@ -75,9 +75,9 @@ export class TransactionSender implements ITransactionSender {
                 } else {
                     return new RpcError("0", "No account or TransactionSigner specified")
                 }
+            } else {
+                txSignature = signature as TxSignature
             }
-
-            txSignature = signature as TxSignature
 
             if (!typeGuard(txSignature, TxSignature)) {
                 return new RpcError("0", "Error generating signature for transaction")


### PR DESCRIPTION
The current method to create transactions doesn't have a way to use an existing signature for a given transaction (e.g. one generated from a ledger device).

This PR slightly modifies the `createTransaction()` method, in a non-breaking way to make it possible.