### PR TITLE
feat: create unsigned transactions (to be signed later)

### DIFF
--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -1,14 +1,4 @@
-# Quickstart Guide
-
-### Pocket-JS 0.6.8-rc highlight
-
-On the latest version we introduce the new ProtoBuf transaction codec, this functionality is activated on the ```Configuration``` class for Pocket by default, to use the legacy AminoJS transaction codec the ```useLegacyTxCodec``` flag should be set to ```true```.
-
-```
-const useLegacyTxCodec = true;
-const configuration = new Configuration(5, 2000, undefined, 100000, undefined, undefined, undefined, undefined, undefined, undefined, useLegacyTxCodec)
-```
-
+# Quickstart Guide (PocketJS >= 0.7.1-rc)
 
 ### How to Instantiate a Pocket Instance
 For a basic Configuration file we just nee to set the three properties (maxDispatchers, maxSessions and requestTimeOut)

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -14,7 +14,7 @@ export class Configuration {
   public readonly maxSessionRefreshRetries: number = 1
   public readonly validateRelayResponses: boolean = true
   public readonly rejectSelfSignedCertificates: boolean = true
-  public readonly useLegacyTxCodec: boolean = true
+  public readonly useLegacyTxCodec: boolean = false
 
   /**
    * Stores multiple properties used to interact with the Pocket Network.
@@ -43,7 +43,7 @@ export class Configuration {
     maxSessionRefreshRetries: number = 1,
     validateRelayResponses: boolean = true,
     rejectSelfSignedCertificates: boolean = true,
-    useLegacyTxCodec: boolean = true
+    useLegacyTxCodec: boolean = false
   ) {
     this.maxDispatchers = maxDispatchers
     this.maxSessions = maxSessions

--- a/src/transactions/factory/proto-tx-encoder.ts
+++ b/src/transactions/factory/proto-tx-encoder.ts
@@ -4,7 +4,6 @@ import { BaseTxEncoder } from './base-tx-encoder'
 import { ProtoStdSignature, ProtoStdTx } from '../models/proto/generated/tx-signer'
 import * as varint from "varint"
 import { Any } from '../models/proto'
-import { StdSignDoc } from '..'
 
 export class ProtoTxEncoder extends BaseTxEncoder {
 
@@ -28,12 +27,31 @@ export class ProtoTxEncoder extends BaseTxEncoder {
         return Buffer.from(JSON.stringify(stdSignDoc), "utf-8")
     }
 
+    // Returns the bytes to be signed by the account sending the transaction
+    // The key difference from the above is that this can be used to obtain 
+    // the unsigned tx bytes without the use of a signer
+    static marshalStdSignDoc(chainID: string, entropy: string, fee: string, msg: any, memo?: string, feeDenom?: "Upokt" | "Pokt"): Buffer {
+        const stdSignDoc = {
+            chain_id: chainID,
+            entropy,
+            fee: [{
+                amount: fee,
+                denom: feeDenom !== undefined ? CoinDenom[feeDenom].toLowerCase() : 'upokt'
+            }],
+            memo,
+            msg
+        }
+
+        return Buffer.from(JSON.stringify(stdSignDoc), "utf-8")
+    }
+
     // Returns the signed encoded transaction
     public marshalStdTx(signature: TxSignature): Buffer {
         const txSig: ProtoStdSignature = {
             publicKey: signature.pubKey, 
             Signature: signature.signature
         }
+
         const stdTx: ProtoStdTx = {
             msg: this.msg.toStdTxMsgObj(), 
             fee: this.getFeeObj(), 
@@ -55,25 +73,27 @@ export class ProtoTxEncoder extends BaseTxEncoder {
     
     // Returns the signed encoded transaction,
     // The key difference from the above is that this can be called with an external stdTxMsg object
-    static marshalStdSignDoc(stdTxMsgObj: Any, stdSignDoc: StdSignDoc, signature: TxSignature) : Buffer {
+    static marshalStdTx(stdTxMsgObj: Any, stdSignDoc: any, signature: TxSignature) : Buffer {
         const txSig: ProtoStdSignature = {
             publicKey: signature.pubKey, 
             Signature: signature.signature
         }
-        
+
         const stdTx: ProtoStdTx = {
             msg: stdTxMsgObj, 
-            fee: [{ amount: stdSignDoc.fee, denom: stdSignDoc.feeDenom}],
+            fee: stdSignDoc.fee,
             signature: txSig, 
             memo: stdSignDoc.memo, 
-            entropy: parseInt(stdSignDoc.entropy, 10)
+            entropy: parseInt(stdSignDoc.entropy, 10),
         }
+
 
         // Create the Proto Std Tx bytes
         const protoStdTxBytes: Buffer = Buffer.from(ProtoStdTx.encode(stdTx).finish())
 
         // Create the prefix
         const prefixBytes = varint.encode(protoStdTxBytes.length)
+
         const prefix = Buffer.from(prefixBytes)
 
         // Concatenate for the result

--- a/src/transactions/i-transaction-sender.ts
+++ b/src/transactions/i-transaction-sender.ts
@@ -42,6 +42,22 @@ export interface ITransactionSender {
     ): Promise<RawTxRequest | RpcError>
 
     /**
+     * Creates an unsigned transaction hex that can be signed with a valid ed25519 private key
+     * @param {string} chainID - The chainID of the network to be sent to
+     * @param {string} fee - The amount to pay as a fee for executing this transaction
+     * @param {CoinDenom | undefined} feeDenom - The denomination of the fee amount 
+     * @param {string | undefined} memo - The memo field for this account
+     * @returns {{ bytesToSign: string, encodedMsg: string } | RpcError} - bytes to sign and the stringified stxTxMsgObj
+     * @memberof TransactionSender
+     */
+     createUnsignedTransaction(
+        chainID: string,
+        fee: string,
+        feeDenom?: CoinDenom,
+        memo?: string
+    ): { bytesToSign: string, stdTxMsgObj: string } | RpcError
+
+    /**
      * Adds a MsgSend TxMsg for this transaction
      * @param {string} fromAddress - Origin address
      * @param {string} toAddress - Destination address

--- a/src/transactions/i-transaction-sender.ts
+++ b/src/transactions/i-transaction-sender.ts
@@ -45,6 +45,7 @@ export interface ITransactionSender {
      * Creates an unsigned transaction hex that can be signed with a valid ed25519 private key
      * @param {string} chainID - The chainID of the network to be sent to
      * @param {string} fee - The amount to pay as a fee for executing this transaction
+     * @param {string} entropy - The entropy for this tx
      * @param {CoinDenom | undefined} feeDenom - The denomination of the fee amount 
      * @param {string | undefined} memo - The memo field for this account
      * @returns {{ bytesToSign: string, encodedMsg: string } | RpcError} - bytes to sign and the stringified stxTxMsgObj
@@ -53,8 +54,9 @@ export interface ITransactionSender {
      createUnsignedTransaction(
         chainID: string,
         fee: string,
+        entropy: string,
         feeDenom?: CoinDenom,
-        memo?: string
+        memo?: string,
     ): { bytesToSign: string, stdTxMsgObj: string } | RpcError
 
     /**

--- a/src/transactions/models/msgs/msg-proto-send.ts
+++ b/src/transactions/models/msgs/msg-proto-send.ts
@@ -62,4 +62,8 @@ export class MsgProtoSend extends TxMsg {
 
         return result;
     }
+
+    static decodeStdTxMsgValue(value: string): any {
+        return MsgSend.decode(Buffer.from(value, 'base64'))
+    }
 }

--- a/src/transactions/transaction-sender.ts
+++ b/src/transactions/transaction-sender.ts
@@ -75,13 +75,13 @@ export class TransactionSender implements ITransactionSender {
                 } else {
                     return new RpcError("0", "No account or TransactionSigner specified")
                 }
-    
-                if (!typeGuard(txSignature, TxSignature)) {
-                    return new RpcError("0", "Error generating signature for transaction")
-                }
             }
 
             txSignature = signature as TxSignature
+
+            if (!typeGuard(txSignature, TxSignature)) {
+                return new RpcError("0", "Error generating signature for transaction")
+            }
 
             const addressHex = addressFromPublickey(txSignature.pubKey)
             const encodedTxBytes = signer.marshalStdTx(txSignature)

--- a/src/transactions/transaction-sender.ts
+++ b/src/transactions/transaction-sender.ts
@@ -46,7 +46,8 @@ export class TransactionSender implements ITransactionSender {
         chainID: string,
         fee: string,
         feeDenom?: CoinDenom,
-        memo?: string
+        memo?: string,
+        signature?: TxSignature
     ): Promise<RawTxRequest | RpcError> {
         try {
             if (this.txMsgError !== undefined) {
@@ -62,21 +63,26 @@ export class TransactionSender implements ITransactionSender {
 
             const entropy = Number(BigInt(Math.floor(Math.random() * Number.MAX_SAFE_INTEGER)).toString()).toString()
             const signer = TxEncoderFactory.createEncoder(entropy, chainID, this.txMsg, fee, feeDenom, memo, this.pocket.configuration.useLegacyTxCodec)
-            let txSignatureOrError
-            const bytesToSign = signer.marshalStdSignDoc()
-            if (typeGuard(this.unlockedAccount, UnlockedAccount)) {
-                txSignatureOrError = await this.signWithUnlockedAccount(bytesToSign, this.unlockedAccount as UnlockedAccount)
-            } else if (this.txSigner !== undefined) {
-                txSignatureOrError = this.signWithTrasactionSigner(bytesToSign, this.txSigner as TransactionSigner)
-            } else {
-                return new RpcError("0", "No account or TransactionSigner specified")
+            
+            let txSignature
+
+            if (!signature) {
+                const bytesToSign = signer.marshalStdSignDoc()
+                if (typeGuard(this.unlockedAccount, UnlockedAccount)) {
+                    txSignature = await this.signWithUnlockedAccount(bytesToSign, this.unlockedAccount as UnlockedAccount)
+                } else if (this.txSigner !== undefined) {
+                    txSignature = this.signWithTrasactionSigner(bytesToSign, this.txSigner as TransactionSigner)
+                } else {
+                    return new RpcError("0", "No account or TransactionSigner specified")
+                }
+    
+                if (!typeGuard(txSignature, TxSignature)) {
+                    return new RpcError("0", "Error generating signature for transaction")
+                }
             }
 
-            if (!typeGuard(txSignatureOrError, TxSignature)) {
-                return new RpcError("0", "Error generating signature for transaction")
-            }
+            txSignature = signature as TxSignature
 
-            const txSignature = txSignatureOrError as TxSignature
             const addressHex = addressFromPublickey(txSignature.pubKey)
             const encodedTxBytes = signer.marshalStdTx(txSignature)
             // Clean message and error

--- a/src/transactions/transaction-sender.ts
+++ b/src/transactions/transaction-sender.ts
@@ -99,15 +99,15 @@ export class TransactionSender implements ITransactionSender {
      * @param {string} fee - The amount to pay as a fee for executing this transaction
      * @param {CoinDenom | undefined} feeDenom - The denomination of the fee amount 
      * @param {string | undefined} memo - The memo field for this account
-     * @returns {Promise<{ bytesToSign: string, encodedMsg: string } | RpcError>} - bytes to sign and the stringified stxTxMsgObj
+     * @returns {Promise<{ bytesToSign: string, stdTxMsgObj: string } | RpcError>} - bytes to sign and the stringified stxTxMsgObj
      * @memberof TransactionSender
      */
-     public async createUnsignedTransaction(
+     public createUnsignedTransaction(
         chainID: string,
         fee: string,
         feeDenom?: CoinDenom,
         memo?: string
-    ): Promise<{ bytesToSign: string, stdTxMsgObj: string } | RpcError> {
+    ): { bytesToSign: string, stdTxMsgObj: string } | RpcError {
         try {
             if (this.txMsgError !== undefined) {
                 const rpcError = RpcError.fromError(this.txMsgError)

--- a/src/transactions/transaction-signer.ts
+++ b/src/transactions/transaction-signer.ts
@@ -24,9 +24,8 @@ export class ProtoTransactionSigner {
         try {
             const stdSignDoc = JSON.parse(Buffer.from(bytesToSign, 'hex').toString('utf-8'))
             const stdTxMsgObj = Any.fromJSON(JSON.parse(encodedMsg))
-    
             const addressHex = addressFromPublickey(txSignature.pubKey)
-            const encodedTxBytes = ProtoTxEncoder.marshalStdSignDoc(stdTxMsgObj, stdSignDoc, txSignature)
+            const encodedTxBytes = ProtoTxEncoder.marshalStdTx(stdTxMsgObj, stdSignDoc, txSignature)
             
             return new RawTxRequest(addressHex.toString('hex'), encodedTxBytes.toString('hex'))
         } catch (error) {

--- a/src/transactions/transaction-signer.ts
+++ b/src/transactions/transaction-signer.ts
@@ -16,13 +16,13 @@ export class ProtoTransactionSigner {
      * @returns {Promise<RawTxRequest | RpcError>} - A Raw transaction Response object or Rpc error.
      * @memberof ProtoTransactionSigner
      */
-     public signTransaction(
+     public static signTransaction(
         encodedMsg: string,
         bytesToSign: string,
         txSignature: TxSignature
     ):  RawTxRequest | RpcError {
         try {
-            const stdSignDoc = this.decodeUnsignedTxBytes(bytesToSign)
+            const stdSignDoc = JSON.parse(Buffer.from(bytesToSign, 'hex').toString('utf-8'))
             const stdTxMsgObj = Any.fromJSON(JSON.parse(encodedMsg))
     
             const addressHex = addressFromPublickey(txSignature.pubKey)
@@ -32,10 +32,5 @@ export class ProtoTransactionSigner {
         } catch (error) {
             return RpcError.fromError(error as Error)
         }
-    }
-    
-    // Converts unsigned transaction bytes (so called bytesToSign) into it's raw representation.
-    decodeUnsignedTxBytes(unsignedTxBytes: string): StdSignDoc {
-        return JSON.parse(Buffer.from(unsignedTxBytes, 'hex').toString('utf-8'))
     }
 }

--- a/src/transactions/transaction-signer.ts
+++ b/src/transactions/transaction-signer.ts
@@ -1,5 +1,3 @@
-import { RpcError, typeGuard} from ".."
-import { TxSignature } from './models'
 import { TransactionSignature } from "./models/transaction-signature"
 /**
  * Interface function for custom transaction signer object

--- a/src/transactions/transaction-signer.ts
+++ b/src/transactions/transaction-signer.ts
@@ -1,5 +1,6 @@
+import { RpcError, typeGuard} from ".."
+import { TxSignature } from './models'
 import { TransactionSignature } from "./models/transaction-signature"
-
 /**
  * Interface function for custom transaction signer object
  */

--- a/src/transactions/transaction-signer.ts
+++ b/src/transactions/transaction-signer.ts
@@ -1,5 +1,41 @@
-import { TransactionSignature } from "./models/transaction-signature"
+import { ProtoTxEncoder, StdSignDoc } from '.'
+import { addressFromPublickey, RawTxRequest, RpcError, TxSignature } from '..'
+import { Any } from './models/proto'
+import { TransactionSignature } from './models/transaction-signature'
 /**
  * Interface function for custom transaction signer object
  */
 export type TransactionSigner = (encodedTxBytes: Buffer) => TransactionSignature | Error
+
+export class ProtoTransactionSigner {
+    /**
+     * Sign an unsigned transaction with a valid ed25519 signature
+     * @param {string} encodedMsg - stxTxMsgObj stringified
+     * @param {string} bytesToSign - the unsigned transaction bytes
+     * @param {TxSignature} txSignature - valid ed25519 signature and public key
+     * @returns {Promise<RawTxRequest | RpcError>} - A Raw transaction Response object or Rpc error.
+     * @memberof ProtoTransactionSigner
+     */
+     public signTransaction(
+        encodedMsg: string,
+        bytesToSign: string,
+        txSignature: TxSignature
+    ):  RawTxRequest | RpcError {
+        try {
+            const stdSignDoc = this.decodeUnsignedTxBytes(bytesToSign)
+            const stdTxMsgObj = Any.fromJSON(JSON.parse(encodedMsg))
+    
+            const addressHex = addressFromPublickey(txSignature.pubKey)
+            const encodedTxBytes = ProtoTxEncoder.marshalStdSignDoc(stdTxMsgObj, stdSignDoc, txSignature)
+            
+            return new RawTxRequest(addressHex.toString('hex'), encodedTxBytes.toString('hex'))
+        } catch (error) {
+            return RpcError.fromError(error as Error)
+        }
+    }
+    
+    // Converts unsigned transaction bytes (so called bytesToSign) into it's raw representation.
+    decodeUnsignedTxBytes(unsignedTxBytes: string): StdSignDoc {
+        return JSON.parse(Buffer.from(unsignedTxBytes, 'hex').toString('utf-8'))
+    }
+}


### PR DESCRIPTION
There's no way to generate an unsigned transaction with the current functionalities. This PR adds a new method called `createUnsignedTransaction()` that will generate an unsigned transaction that can be signed later with a valid ed25519 private key.

This is useful to not limit devs to depend on our SDK to sign transactions.

Builds on #442.