### PR TITLE
FIX: Proto encoding misses payload conversion to base64

### DIFF
--- a/src/transactions/models/msgs/msg-proto-node-stake.ts
+++ b/src/transactions/models/msgs/msg-proto-node-stake.ts
@@ -87,7 +87,7 @@ export class MsgProtoNodeStakeTx extends TxMsg {
 
         return Any.fromJSON({
             "typeUrl": this.KEY,
-            "value": MsgProtoNodeStake.encode(data).finish()
+            "value": Buffer.from(MsgProtoNodeStake.encode(data).finish()).toString("base64")
         });
     }
 }


### PR DESCRIPTION
Using the library I ran into an error while trying to call the `nodeStake` method using the proto implementation; `RpcError: Invalid character `


After taking a look I noticed `toStdTxMsgObj` not adhering to the standard of serializing the payload to base64 like in other messages. This PR fixes this and resolves my issue. 