### PR TITLE
fix: error not handled properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pokt-network/pocket-js",
-    "version": "0.7.1-rc",
+    "version": "0.7.2-rc",
     "engine": {
         "node": ">=12.16.0 <=16.13.0"
     },

--- a/src/rpc/models/stdtx.ts
+++ b/src/rpc/models/stdtx.ts
@@ -18,7 +18,7 @@ export type Signature = { pub_key: string, signature: string }
     try {
       const jsonObject = JSON.parse(json)
       
-      const fee = { amount: jsonObject.fee[0].amount, denom: jsonObject.fee[0].denom }
+      const fee = { amount: jsonObject.fee[0]?.amount, denom: jsonObject.fee[0]?.denom }
       const msg = jsonObject.msg || {}
 
       const signature = { pub_key: jsonObject.signature.pub_key, signature: jsonObject.signature.signature }


### PR DESCRIPTION
This was causing the `getBlockTxs` method to crash, because an invalid transaction comes with an empty fee field. The PR makes those optional so it doesn't crash and is able to decode those invalid txs.