### PR TITLE
Mark alreadyInConsensus flag correctly

### DIFF
--- a/src/pocket.ts
+++ b/src/pocket.ts
@@ -437,8 +437,8 @@ export class Pocket {
         }
       } else if (consensusEnabled && typeGuard(result, RelayResponse)) {
         // Handle consensus
-        if (currentSession.sessionNodes.indexOf(serviceNode)) {
-          currentSession.sessionNodes[currentSession.sessionNodes.indexOf(serviceNode)].alreadyInConsensus = true
+        if (currentSession.sessionNodes.indexOf(serviceNode) >= 0) {
+          serviceNode.alreadyInConsensus = true;
         }
         return new ConsensusNode(serviceNode, false, result)
       } else {


### PR DESCRIPTION
Currently the first item in `currentSession` never gets `alreadyInConsensus=true`.  As a result, `sendConsensusRelay` does not relays a transaction to nodes equally.