### PR TITLE
fix: unsigned tx not generating the correct bytes to be signed

### DIFF
--- a/src/transactions/factory/proto-tx-encoder.ts
+++ b/src/transactions/factory/proto-tx-encoder.ts
@@ -4,7 +4,6 @@ import { BaseTxEncoder } from './base-tx-encoder'
 import { ProtoStdSignature, ProtoStdTx } from '../models/proto/generated/tx-signer'
 import * as varint from "varint"
 import { Any } from '../models/proto'
-import { StdSignDoc } from '..'
 
 export class ProtoTxEncoder extends BaseTxEncoder {
 
@@ -28,12 +27,31 @@ export class ProtoTxEncoder extends BaseTxEncoder {
         return Buffer.from(JSON.stringify(stdSignDoc), "utf-8")
     }
 
+    // Returns the bytes to be signed by the account sending the transaction
+    // The key difference from the above is that this can be used to obtain 
+    // the unsigned tx bytes without the use of a signer
+    static marshalStdSignDoc(chainID: string, entropy: string, fee: string, msg: any, memo?: string, feeDenom?: "Upokt" | "Pokt"): Buffer {
+        const stdSignDoc = {
+            chain_id: chainID,
+            entropy,
+            fee: [{
+                amount: fee,
+                denom: feeDenom !== undefined ? CoinDenom[feeDenom].toLowerCase() : 'upokt'
+            }],
+            memo,
+            msg
+        }
+
+        return Buffer.from(JSON.stringify(stdSignDoc), "utf-8")
+    }
+
     // Returns the signed encoded transaction
     public marshalStdTx(signature: TxSignature): Buffer {
         const txSig: ProtoStdSignature = {
             publicKey: signature.pubKey, 
             Signature: signature.signature
         }
+
         const stdTx: ProtoStdTx = {
             msg: this.msg.toStdTxMsgObj(), 
             fee: this.getFeeObj(), 
@@ -55,25 +73,27 @@ export class ProtoTxEncoder extends BaseTxEncoder {
     
     // Returns the signed encoded transaction,
     // The key difference from the above is that this can be called with an external stdTxMsg object
-    static marshalStdSignDoc(stdTxMsgObj: Any, stdSignDoc: StdSignDoc, signature: TxSignature) : Buffer {
+    static marshalStdTx(stdTxMsgObj: Any, stdSignDoc: any, signature: TxSignature) : Buffer {
         const txSig: ProtoStdSignature = {
             publicKey: signature.pubKey, 
             Signature: signature.signature
         }
-        
+
         const stdTx: ProtoStdTx = {
             msg: stdTxMsgObj, 
-            fee: [{ amount: stdSignDoc.fee, denom: stdSignDoc.feeDenom}],
+            fee: stdSignDoc.fee,
             signature: txSig, 
             memo: stdSignDoc.memo, 
-            entropy: parseInt(stdSignDoc.entropy, 10)
+            entropy: parseInt(stdSignDoc.entropy, 10),
         }
+
 
         // Create the Proto Std Tx bytes
         const protoStdTxBytes: Buffer = Buffer.from(ProtoStdTx.encode(stdTx).finish())
 
         // Create the prefix
         const prefixBytes = varint.encode(protoStdTxBytes.length)
+
         const prefix = Buffer.from(prefixBytes)
 
         // Concatenate for the result

--- a/src/transactions/i-transaction-sender.ts
+++ b/src/transactions/i-transaction-sender.ts
@@ -45,6 +45,7 @@ export interface ITransactionSender {
      * Creates an unsigned transaction hex that can be signed with a valid ed25519 private key
      * @param {string} chainID - The chainID of the network to be sent to
      * @param {string} fee - The amount to pay as a fee for executing this transaction
+     * @param {string} entropy - The entropy for this tx
      * @param {CoinDenom | undefined} feeDenom - The denomination of the fee amount 
      * @param {string | undefined} memo - The memo field for this account
      * @returns {{ bytesToSign: string, encodedMsg: string } | RpcError} - bytes to sign and the stringified stxTxMsgObj
@@ -53,8 +54,9 @@ export interface ITransactionSender {
      createUnsignedTransaction(
         chainID: string,
         fee: string,
+        entropy: string,
         feeDenom?: CoinDenom,
-        memo?: string
+        memo?: string,
     ): { bytesToSign: string, stdTxMsgObj: string } | RpcError
 
     /**

--- a/src/transactions/transaction-signer.ts
+++ b/src/transactions/transaction-signer.ts
@@ -24,9 +24,8 @@ export class ProtoTransactionSigner {
         try {
             const stdSignDoc = JSON.parse(Buffer.from(bytesToSign, 'hex').toString('utf-8'))
             const stdTxMsgObj = Any.fromJSON(JSON.parse(encodedMsg))
-    
             const addressHex = addressFromPublickey(txSignature.pubKey)
-            const encodedTxBytes = ProtoTxEncoder.marshalStdSignDoc(stdTxMsgObj, stdSignDoc, txSignature)
+            const encodedTxBytes = ProtoTxEncoder.marshalStdTx(stdTxMsgObj, stdSignDoc, txSignature)
             
             return new RawTxRequest(addressHex.toString('hex'), encodedTxBytes.toString('hex'))
         } catch (error) {


### PR DESCRIPTION
- Adds new static marshalStdSignDoc that properly generates the bytes to be signed
- Adds entropy parameter to createUsignedTx. Since the tx is signed outside of the SDK this field needs to come from the user and not be generated on the SDK side.
- Fixes marshalStdTx not using the right values to create the protoStdTxBytes
